### PR TITLE
Generate new ready event type

### DIFF
--- a/app/lambdas/bssh_fastq_copy_succeeded_to_bclconvert_interop_qc_ready_py/bssh_fastq_copy_succeeded_to_bclconvert_interop_qc_ready.py
+++ b/app/lambdas/bssh_fastq_copy_succeeded_to_bclconvert_interop_qc_ready_py/bssh_fastq_copy_succeeded_to_bclconvert_interop_qc_ready.py
@@ -97,7 +97,7 @@ def handler(event, context) -> Dict[str, Dict[str, Any]]:
     portal_run_id = event["portalRunId"]
     instrument_run_id = event["instrumentRunId"]
     primary_data_output_uri = event["primaryDataOutputUri"]
-    linked_libraries = event["linkedLibraries"]
+    libraries = event["libraries"]
     workflow_output_uri_prefix = event["workflowOutputPrefix"]
     workflow_logs_uri_prefix = event["workflowLogsPrefix"]
 
@@ -110,14 +110,17 @@ def handler(event, context) -> Dict[str, Dict[str, Any]]:
           "timestamp": datetime.now(timezone.utc).isoformat(timespec='seconds').replace("+00:00", 'Z'),
           # Portal Run ID For the BSSH Fastq Copy Manager
           "portalRunId": portal_run_id,  # pragma: allowlist secret
-          # Workflow name
-          "workflowName": workflow_name,
-          # Workflow version
-          "workflowVersion": workflow_version,
+          # Workflow
+          "workflow": {
+              # Workflow name
+              "name": workflow_name,
+              # Workflow version
+              "version": workflow_version
+          },
           # Workflow run name
           "workflowRunName": workflow_run_name,
           # Linked libraries in the instrument run
-          "linkedLibraries": linked_libraries,
+          "libraries": libraries,
           "payload": {
             "version": payload_version,
             "data": {

--- a/app/step-functions-templates/bssh_fastq_to_aws_wrsc_to_ready_wrsc_sfn_template.asl.json
+++ b/app/step-functions-templates/bssh_fastq_to_aws_wrsc_to_ready_wrsc_sfn_template.asl.json
@@ -8,7 +8,7 @@
       "Assign": {
         "instrumentRunId": "{% $states.input.instrumentRunId %}",
         "primaryDataOutputUri": "{% $states.input.primaryDataOutputUri %}",
-        "linkedLibraries": "{% $states.input.linkedLibraries %}"
+        "libraries": "{% $states.input.libraries %}"
       }
     },
     "Get workflow name and version from ssm parameters": {
@@ -149,7 +149,7 @@
           "portalRunId": "{% $portalRunId %}",
           "instrumentRunId": "{% $instrumentRunId %}",
           "primaryDataOutputUri": "{% $primaryDataOutputUri %}",
-          "linkedLibraries": "{% $linkedLibraries %}"
+          "libraries": "{% $libraries %}"
         }
       },
       "Retry": [
@@ -166,10 +166,21 @@
           "JitterStrategy": "FULL"
         }
       ],
-      "Next": "Push BCLConvert InterOp QC Ready Event",
+      "Next": "Has new workflow manager been deployed",
       "Output": {
         "bclconvertInterOpQcEventDetail": "{% $states.result.Payload.bclconvertInterOpQcEventDetail %}"
       }
+    },
+    "Has new workflow manager been deployed": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Next": "Push BCLConvert InterOp QC Ready Event",
+          "Condition": "{% /* ${__new_workflow_manager_is_deployed__} */ false %}",
+          "Comment": "New workflow manager is deployed"
+        }
+      ],
+      "Default": "Push BCLConvert InterOp QC Ready Event (Legacy)"
     },
     "Push BCLConvert InterOp QC Ready Event": {
       "Type": "Task",
@@ -178,6 +189,21 @@
         "Entries": [
           {
             "Detail": "{% $states.input.bclconvertInterOpQcEventDetail %}",
+            "DetailType": "${__workflow_run_state_change_event_detail_type__}",
+            "EventBusName": "${__event_bus_name__}",
+            "Source": "${__event_source__}"
+          }
+        ]
+      },
+      "End": true
+    },
+    "Push BCLConvert InterOp QC Ready Event (Legacy)": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::events:putEvents",
+      "Arguments": {
+        "Entries": [
+          {
+            "Detail": "{% $states.input.bclconvertInterOpQcEventDetail ~>\n/* Renamed libraries to linkedLibraries using the transform method */\n| $ | {\"linkedLibraries\": libraries}, [\"libraries\"] | ~>\n/* Renamed workflowName and workflowVersion using the transform method */\n| $ | {\"workflowName\": workflow.name, \"workflowVersion\": workflow.version}, [\"workflow\"] | %}",
             "DetailType": "${__workflow_run_state_change_event_detail_type__}",
             "EventBusName": "${__event_bus_name__}",
             "Source": "${__event_source__}"

--- a/app/step-functions-templates/icav2_wes_event_to_wrsc_event_sfn_template.asl.json
+++ b/app/step-functions-templates/icav2_wes_event_to_wrsc_event_sfn_template.asl.json
@@ -35,7 +35,7 @@
       "Choices": [
         {
           "Next": "Push WRSC Event",
-          "Condition": "{% ${__new_workflow_manager_is_deployed__} %}",
+          "Condition": "{% /* ${__new_workflow_manager_is_deployed__} */ false %}",
           "Comment": "Has new workflow manager been pushed yet?"
         }
       ],

--- a/infrastructure/stage/event-rules/index.ts
+++ b/infrastructure/stage/event-rules/index.ts
@@ -65,12 +65,25 @@ function buildWorkflowManagerReadyEventPattern(): EventPattern {
   };
 }
 
-function buildBsshFastqCopyToAwsSucceededEventPattern(): EventPattern {
+function buildBsshFastqCopyToAwsSucceededEventPatternLegacy(): EventPattern {
   return {
     detailType: [WORKFLOW_RUN_STATE_CHANGE_DETAIL_TYPE],
     source: [WORKFLOW_MANAGER_EVENT_SOURCE],
     detail: {
       workflowName: [BSSH_FASTQ_COPY_TO_AWS_WORKFLOW_RUN_NAME],
+      status: [SUCCEEDED_STATUS],
+    },
+  };
+}
+
+function buildBsshFastqCopyToAwsSucceededEventPattern(): EventPattern {
+  return {
+    detailType: [WORKFLOW_RUN_STATE_CHANGE_DETAIL_TYPE],
+    source: [WORKFLOW_MANAGER_EVENT_SOURCE],
+    detail: {
+      workflow: {
+        name: [BSSH_FASTQ_COPY_TO_AWS_WORKFLOW_RUN_NAME],
+      },
       status: [SUCCEEDED_STATUS],
     },
   };
@@ -84,13 +97,24 @@ function buildEventRule(scope: Construct, props: EventBridgeRuleProps): Rule {
   });
 }
 
-function buildIcav2WesAnalysisStateChangeRule(
+function buildWorkflowRunStateChangeBsshFastqCopySucceededEventRuleLegacy(
   scope: Construct,
-  props: BuildIcav2AnalysisStateChangeRuleProps
+  props: BuildBsshFastqCopySucceededRuleProps
 ): Rule {
   return buildEventRule(scope, {
     ruleName: props.ruleName,
-    eventPattern: buildIcav2AnalysisStateChangeEventPattern(),
+    eventPattern: buildBsshFastqCopyToAwsSucceededEventPatternLegacy(),
+    eventBus: props.eventBus,
+  });
+}
+
+function buildWorkflowRunStateChangeBsshFastqCopySucceededEventRule(
+  scope: Construct,
+  props: BuildBsshFastqCopySucceededRuleProps
+): Rule {
+  return buildEventRule(scope, {
+    ruleName: props.ruleName,
+    eventPattern: buildBsshFastqCopyToAwsSucceededEventPattern(),
     eventBus: props.eventBus,
   });
 }
@@ -117,13 +141,13 @@ function buildWorkflowRunStateChangeBclconvertInteropQcReadyEventRule(
   });
 }
 
-function buildWorkflowRunStateChangeBsshFastqCopySucceededEventRule(
+function buildIcav2WesAnalysisStateChangeRule(
   scope: Construct,
-  props: BuildBsshFastqCopySucceededRuleProps
+  props: BuildIcav2AnalysisStateChangeRuleProps
 ): Rule {
   return buildEventRule(scope, {
     ruleName: props.ruleName,
-    eventPattern: buildBsshFastqCopyToAwsSucceededEventPattern(),
+    eventPattern: buildIcav2AnalysisStateChangeEventPattern(),
     eventBus: props.eventBus,
   });
 }
@@ -137,6 +161,16 @@ export function buildAllEventRules(
   // Iterate over the eventBridgeNameList and create the event rules
   for (const ruleName of eventBridgeRuleNameList) {
     switch (ruleName) {
+      case 'bsshToAwsS3CopySucceededEventLegacy': {
+        eventBridgeRuleObjects.push({
+          ruleName: ruleName,
+          ruleObject: buildWorkflowRunStateChangeBsshFastqCopySucceededEventRuleLegacy(scope, {
+            ruleName: ruleName,
+            eventBus: props.eventBus,
+          }),
+        });
+        break;
+      }
       case 'bsshToAwsS3CopySucceededEvent': {
         eventBridgeRuleObjects.push({
           ruleName: ruleName,

--- a/infrastructure/stage/event-rules/interfaces.ts
+++ b/infrastructure/stage/event-rules/interfaces.ts
@@ -4,12 +4,14 @@ import { EventPattern, IEventBus, Rule } from 'aws-cdk-lib/aws-events';
  * EventBridge Rules Interfaces
  */
 export type EventBridgeRuleNameList =
+  | 'bsshToAwsS3CopySucceededEventLegacy'
   | 'bsshToAwsS3CopySucceededEvent'
   | 'ReadyEventLegacy'
   | 'ReadyEvent'
   | 'Icav2WascEvent';
 
 export const eventBridgeRuleNameList: EventBridgeRuleNameList[] = [
+  'bsshToAwsS3CopySucceededEventLegacy',
   'bsshToAwsS3CopySucceededEvent',
   'ReadyEventLegacy',
   'ReadyEvent',

--- a/infrastructure/stage/event-targets/interfaces.ts
+++ b/infrastructure/stage/event-targets/interfaces.ts
@@ -7,6 +7,7 @@ import { StepFunctionObject } from '../step-functions/interfaces';
  * EventBridge Target Interfaces
  */
 export type EventBridgeTargetNameList =
+  | 'bsshFastqCopySucceededLegacyToBclconvertInteropQcReadySfnTarget'
   | 'bsshFastqCopySucceededToBclconvertInteropQcReadySfnTarget'
   | 'bclconvertInteropQcReadyLegacyToIcav2WesSubmittedSfnTarget'
   | 'bclconvertInteropQcReadyToIcav2WesSubmittedSfnTarget'


### PR DESCRIPTION
New ready event type isn't quite there but we can at least make event rules for both new event types and legacy event types while continuing to push legacy events.